### PR TITLE
Detection script fix for invalid return command

### DIFF
--- a/utils/find-library-for-appid.sh
+++ b/utils/find-library-for-appid.sh
@@ -6,7 +6,7 @@ steam_dir=$(readlink -f "$HOME/.steam/root")
 
 if [ -n "$STEAM_LIBRARY" ]; then
 	echo "$STEAM_LIBRARY/steamapps/compatdata/$appid"
-	return 0
+	exit 0
 fi
 
 steam_install_candidates=( \
@@ -41,10 +41,10 @@ for libdir in "${steam_libraries[@]}"; do
 	if [ -d "$compat_data" ]; then
 		echo "Found game" >&2
 		echo "$libdir"
-		return 0
+		exit 0
 	fi
 done
 
 echo "ERROR: could not find game with APPID '$appid'" >&2
-return 1
+exit 1
 


### PR DESCRIPTION
Changed to return to exit, this broke installation script saying game was not found in steam library.